### PR TITLE
Add synced lyric display with karaoke highlight effect

### DIFF
--- a/taskbar-fluent-media-player.wh.cpp
+++ b/taskbar-fluent-media-player.wh.cpp
@@ -342,8 +342,14 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
       $name: Lyric margin (left right)
       $description: Margin around the lyric text, left and right spacing in pixels.
     - lyricColor: "255 255 255"
-      $name: Lyric text color (RGB)
-      $description: Text color as R G B values. Use "-1 -1 -1" for system accent color.
+      $name: Lyric base color (RGB)
+      $description: Base text color as R G B values. Use "-1 -1 -1" for system accent color.
+    - enableLyricKaraoke: true
+      $name: Enable lyric karaoke effect
+      $description: Highlight the current lyric progress with a smooth karaoke-style sweep.
+    - lyricHighlightColor: "30 215 96"
+      $name: Lyric highlight color (RGB)
+      $description: Karaoke highlight color as R G B values. Use "-1 -1 -1" for system accent color.
     - lyricMaxWidth: "256"
       $name: Lyric max width (px)
       $description: Maximum width of the lyric text area. Set to 0 for no limit. When text exceeds this width, it scrolls.
@@ -1208,6 +1214,8 @@ struct ModSettings {
     int          lyricMarginLeft        = 4;
     int          lyricMarginRight       = 4;
     std::wstring lyricColor             = L"255 255 255";
+    bool         enableLyricKaraoke     = true;
+    std::wstring lyricHighlightColor    = L"30 215 96";
     int          lyricMaxWidth          = 256;
     int          lyricTimeOffset        = 0;
     bool         hideLyricWhenNoLyrics  = false;
@@ -1617,6 +1625,8 @@ static void LoadSettings() {
 
     g_settings.showLyric                = Wh_GetIntSetting(L"MainSettings.LyricSettings.showLyric") != 0;
     g_settings.lyricColor               = Str(L"MainSettings.LyricSettings.lyricColor", L"255 255 255");
+    g_settings.enableLyricKaraoke       = Wh_GetIntSetting(L"MainSettings.LyricSettings.enableLyricKaraoke") != 0;
+    g_settings.lyricHighlightColor      = Str(L"MainSettings.LyricSettings.lyricHighlightColor", L"30 215 96");
     g_settings.lyricMaxWidth            = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricMaxWidth");
     g_settings.lyricTimeOffset          = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricTimeOffset");
     g_settings.hideLyricWhenNoLyrics    = Wh_GetIntSetting(L"MainSettings.LyricSettings.hideLyricWhenNoLyrics") != 0;
@@ -4133,12 +4143,17 @@ static void TickScrollState(TextScrollState& s, int stepPx, int pauseMs, const s
 }
 
 static void UpdateScrollTransforms();
+static void UpdateLyricKaraokeFromCurrentPosition();
 
 static void ScrollTimerTick(winrt::Windows::Foundation::IInspectable const&,
                              winrt::Windows::Foundation::IInspectable const&) {
     if (g_unloading || g_applyingSettings) return;
 
+    bool needsKaraoke = (g_settings.showLyric && g_settings.enableLyricKaraoke);
     bool needsScroll = (g_titleScroll.active || g_artistScroll.active || g_lyricScroll.active);
+    if (needsKaraoke) {
+        UpdateLyricKaraokeFromCurrentPosition();
+    }
     if (!needsScroll) return;
 
     int stepPx = std::max(1, g_settings.scrollSpeed);
@@ -4215,6 +4230,9 @@ static constexpr wchar_t kTitleCloneName[]       = L"FluentMedia_TitleClone";
 static constexpr wchar_t kArtistCloneName[]      = L"FluentMedia_ArtistClone";
 static constexpr wchar_t kLyricScrollViewName[]  = L"FluentMedia_LyricScrollView";
 static constexpr wchar_t kLyricCloneName[]       = L"FluentMedia_LyricClone";
+static constexpr wchar_t kLyricRootName[]        = L"FluentMedia_LyricRoot";
+static constexpr wchar_t kLyricBaseName[]        = L"FluentMedia_Lyric";
+static constexpr wchar_t kLyricHighlightName[]   = L"FluentMedia_LyricHighlight";
 static constexpr wchar_t kPanelGridName[]        = L"FluentMedia_PanelGrid";
 
 static double GetAvailableScrollTextAreaWidth() {
@@ -4250,7 +4268,7 @@ static double GetAvailableScrollTextAreaWidth() {
 
 
 static void UpdateScrollTransforms() {
-    if (!g_playerGrid || (!g_settings.enableTitleScrolling && !g_settings.enableArtistScrolling)) return;
+    if (!g_playerGrid) return;
     bool isLoop = (g_settings.scrollMode == L"loop");
 
     if (g_settings.enableTitleScrolling) {
@@ -4305,7 +4323,7 @@ static void UpdateScrollTransforms() {
                     for (int i = 0; i < n; i++) {
                         auto child = VisualTreeHelper::GetChild(cv, i);
                         if (auto tb = child.try_as<TextBlock>()) {
-                            if (tb.Name() == L"FluentMedia_Lyric") {
+                            if (tb.Name() == kLyricBaseName || tb.Name() == kLyricHighlightName) {
                                 Canvas::SetLeft(tb, -g_lyricScroll.offset);
                             }
                         }
@@ -4314,6 +4332,134 @@ static void UpdateScrollTransforms() {
             }
         } catch (...) {}
     }
+}
+
+static void UpdateLyricHighlightClip(double progress) {
+    if (!g_playerGrid) return;
+
+    progress = std::clamp(progress, 0.0, 1.0);
+
+    try {
+        if (auto fe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
+            if (auto highlightBlock = fe.try_as<TextBlock>()) {
+                double width = highlightBlock.ActualWidth();
+                double height = highlightBlock.ActualHeight();
+                if (height < 1.0) height = 16.0;
+
+                auto geo = highlightBlock.Clip().try_as<winrt::Windows::UI::Xaml::Media::RectangleGeometry>();
+                if (!geo) {
+                    geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
+                    highlightBlock.Clip(geo);
+                }
+                geo.Rect({0, 0, (float)(width * progress), (float)height});
+            }
+        }
+    } catch (...) {}
+}
+
+static double GetLyricProgress(const LyricLine& line, long long currentMs) {
+    long duration = std::max(1L, line.durationMs);
+    double lineProgress = (double)(currentMs - line.startTimeMs) / (double)duration;
+    lineProgress = std::clamp(lineProgress, 0.0, 1.0);
+
+    if (line.words.empty() || line.text.empty()) {
+        return lineProgress;
+    }
+
+    size_t totalChars = line.text.size();
+    if (totalChars == 0) {
+        return lineProgress;
+    }
+
+    size_t charsBefore = 0;
+    for (const auto& word : line.words) {
+        size_t wordChars = word.text.size();
+        long wordStart = word.startTimeMs;
+        long wordDuration = std::max(1L, word.durationMs);
+        long wordEnd = wordStart + wordDuration;
+
+        if (currentMs < wordStart) {
+            return std::clamp((double)charsBefore / (double)totalChars, 0.0, 1.0);
+        }
+
+        if (currentMs < wordEnd) {
+            double wordProgress = (double)(currentMs - wordStart) / (double)wordDuration;
+            double charsDone = (double)charsBefore + (double)wordChars * std::clamp(wordProgress, 0.0, 1.0);
+            return std::clamp(charsDone / (double)totalChars, 0.0, 1.0);
+        }
+
+        charsBefore += wordChars;
+    }
+
+    return 1.0;
+}
+
+static void UpdateLyricKaraokeFromCurrentPosition() {
+    if (!g_playerGrid || !g_settings.showLyric || !g_settings.enableLyricKaraoke) return;
+
+    std::wstring text;
+    double progress = 0.0;
+    long long currentMs = 0;
+    long long durationMs = 0;
+    bool isPlaying = false;
+    std::wstring trackKey;
+
+    try {
+        {
+            std::lock_guard<std::mutex> lk(g_mediaMtx);
+            currentMs = g_media.currentPositionMs + g_settings.lyricTimeOffset;
+            durationMs = g_media.durationMs;
+            isPlaying = g_media.isPlaying;
+            trackKey = g_media.title + L"\n" + g_media.artist;
+        }
+        {
+            static long long anchorPositionMs = -1;
+            static std::wstring anchorTrackKey;
+            static auto anchorTime = std::chrono::steady_clock::now();
+            auto now = std::chrono::steady_clock::now();
+            long long rawPositionMs = currentMs - g_settings.lyricTimeOffset;
+            if (rawPositionMs != anchorPositionMs || trackKey != anchorTrackKey) {
+                anchorPositionMs = rawPositionMs;
+                anchorTrackKey = trackKey;
+                anchorTime = now;
+            } else if (isPlaying && anchorPositionMs >= 0) {
+                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - anchorTime).count();
+                long long estimated = anchorPositionMs + elapsed;
+                if (durationMs > 0) estimated = std::min<long long>(estimated, durationMs);
+                currentMs = estimated + g_settings.lyricTimeOffset;
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
+            for (const auto& line : g_lyricLines) {
+                if (currentMs >= line.startTimeMs && currentMs < line.startTimeMs + line.durationMs) {
+                    text = line.text;
+                    progress = GetLyricProgress(line, currentMs);
+                    break;
+                }
+            }
+        }
+
+        if (!text.empty()) {
+            if (auto baseFe = FindChildByName(g_playerGrid, kLyricBaseName)) {
+                if (auto baseBlock = baseFe.try_as<TextBlock>()) {
+                    if (text != baseBlock.Text().c_str()) {
+                        baseBlock.Text(text);
+                    }
+                }
+            }
+            if (auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
+                if (auto hiBlock = hiFe.try_as<TextBlock>()) {
+                    hiBlock.Visibility(Visibility::Visible);
+                    if (text != hiBlock.Text().c_str()) {
+                        hiBlock.Text(text);
+                    }
+                }
+            }
+        }
+
+        UpdateLyricHighlightClip(progress);
+    } catch (...) {}
 }
 
 static void DispatchMediaUpdate() {
@@ -5405,7 +5551,9 @@ static void StartTimerThread() {
         g_timerUpdateEvent = nullptr;
     }
 
-    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling || g_settings.lyricMaxWidth > 0) {
+    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling ||
+        g_settings.lyricMaxWidth > 0 ||
+        (g_settings.showLyric && g_settings.enableLyricKaraoke)) {
         StartScrollTimer();
     }
 }
@@ -6730,15 +6878,39 @@ static Grid BuildPlayerGrid() {
 
         if (g_settings.showLyric) {
             try {
-                TextBlock lyricBlock;
-                lyricBlock.Name(L"FluentMedia_Lyric");
+                auto makeLyricBlock = [](const wchar_t* name, winrt::Windows::UI::Color color) {
+                    TextBlock block;
+                    block.Name(name);
+                    block.Text(L"...");
+                    block.VerticalAlignment(VerticalAlignment::Center);
+                    block.Foreground(MakeBrush(color));
+                    block.FontSize(12);
+                    block.TextTrimming(TextTrimming::None);
+                    block.TextWrapping(TextWrapping::NoWrap);
+                    return block;
+                };
+
+                TextBlock lyricBlock = makeLyricBlock(
+                    kLyricBaseName,
+                    ParseColorWithThemeSupport(g_settings.lyricColor, 255));
+                TextBlock lyricHighlightBlock = makeLyricBlock(
+                    kLyricHighlightName,
+                    ParseColorWithThemeSupport(g_settings.lyricHighlightColor, 255));
+                lyricHighlightBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+                {
+                    auto geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
+                    geo.Rect({0, 0, 0, 16});
+                    lyricHighlightBlock.Clip(geo);
+                }
                 lyricBlock.Text(L"🎵🎵🎵");
                 lyricBlock.VerticalAlignment(VerticalAlignment::Center);
                 lyricBlock.Foreground(MakeBrush(ParseColorWithThemeSupport(g_settings.lyricColor, 255)));
                 lyricBlock.FontSize(12);
+                lyricHighlightBlock.Text(lyricBlock.Text());
 
                 if (g_settings.lyricMaxWidth > 0) {
                     lyricBlock.Margin({0, 0, 0, 0});
+                    lyricHighlightBlock.Margin({0, 0, 0, 0});
                     Canvas lyricScrollView;
                     lyricScrollView.Name(kLyricScrollViewName);
                     lyricScrollView.VerticalAlignment(VerticalAlignment::Center);
@@ -6749,7 +6921,10 @@ static Grid BuildPlayerGrid() {
                     lyricBlock.TextWrapping(TextWrapping::NoWrap);
                     Canvas::SetLeft(lyricBlock, 0.0);
                     Canvas::SetTop(lyricBlock, 0.0);
+                    Canvas::SetLeft(lyricHighlightBlock, 0.0);
+                    Canvas::SetTop(lyricHighlightBlock, 0.0);
                     lyricScrollView.Children().Append(lyricBlock);
+                    lyricScrollView.Children().Append(lyricHighlightBlock);
 
                     {
                         auto geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
@@ -6771,12 +6946,20 @@ static Grid BuildPlayerGrid() {
                     Grid::SetColumn(lyricScrollView, (int)panel.ColumnDefinitions().Size() - 1);
                     panel.Children().Append(lyricScrollView);
                 } else {
-                    lyricBlock.Margin({(double)g_settings.lyricMarginLeft, 0, (double)g_settings.lyricMarginRight, 0});
+                    Grid lyricRoot;
+                    lyricRoot.Name(kLyricRootName);
+                    lyricRoot.VerticalAlignment(VerticalAlignment::Center);
+                    lyricRoot.Margin({(double)g_settings.lyricMarginLeft, 0, (double)g_settings.lyricMarginRight, 0});
+                    lyricBlock.Margin({0, 0, 0, 0});
+                    lyricHighlightBlock.Margin({0, 0, 0, 0});
+                    lyricRoot.Children().Append(lyricBlock);
+                    lyricRoot.Children().Append(lyricHighlightBlock);
+
                     auto lyricCol = ColumnDefinition();
                     lyricCol.Width({1.0, GridUnitType::Auto});
                     panel.ColumnDefinitions().Append(lyricCol);
-                    Grid::SetColumn(lyricBlock, (int)panel.ColumnDefinitions().Size() - 1);
-                    panel.Children().Append(lyricBlock);
+                    Grid::SetColumn(lyricRoot, (int)panel.ColumnDefinitions().Size() - 1);
+                    panel.Children().Append(lyricRoot);
                 }
             } catch (...) {
                 Wh_Log(L"BuildPlayerGrid: Exception adding lyric text");
@@ -8575,8 +8758,9 @@ static void RefreshPlayerContents() {
 
     if (g_settings.showLyric) {
         try {
-            if (auto lyricFe = FindChildByName(g_playerGrid, L"FluentMedia_Lyric")) {
+            if (auto lyricFe = FindChildByName(g_playerGrid, kLyricBaseName)) {
                 if (auto lyricBlock = lyricFe.try_as<TextBlock>()) {
+                    double lyricProgress = 0.0;
                     std::wstring timeText = L"🎵🎵🎵";
                     long long currentMs = 0;
                     {
@@ -8590,6 +8774,7 @@ static void RefreshPlayerContents() {
                                 if (!line.text.empty()) {
                                     timeText = line.text;
                                 }
+                                lyricProgress = GetLyricProgress(line, currentMs);
                                 break;
                             }
                         }
@@ -8601,8 +8786,10 @@ static void RefreshPlayerContents() {
                                     cv.Visibility(Visibility::Collapsed);
                             }
                         } else {
-                            if (lyricBlock.Visibility() != Visibility::Collapsed)
-                                lyricBlock.Visibility(Visibility::Collapsed);
+                            if (auto root = FindChildByName(g_playerGrid, kLyricRootName)) {
+                                if (root.Visibility() != Visibility::Collapsed)
+                                    root.Visibility(Visibility::Collapsed);
+                            }
                         }
                     } else {
                         if (g_settings.lyricMaxWidth > 0) {
@@ -8611,12 +8798,23 @@ static void RefreshPlayerContents() {
                                     cv.Visibility(Visibility::Visible);
                             }
                         } else {
-                            if (lyricBlock.Visibility() != Visibility::Visible)
-                                lyricBlock.Visibility(Visibility::Visible);
+                            if (auto root = FindChildByName(g_playerGrid, kLyricRootName)) {
+                                if (root.Visibility() != Visibility::Visible)
+                                    root.Visibility(Visibility::Visible);
+                            }
                         }
                         if (timeText != lyricBlock.Text().c_str()) {
                             lyricBlock.Text(timeText);
                         }
+                        if (auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
+                            if (auto hiBlock = hiFe.try_as<TextBlock>()) {
+                                hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+                                if (timeText != hiBlock.Text().c_str()) {
+                                    hiBlock.Text(timeText);
+                                }
+                            }
+                        }
+                        UpdateLyricHighlightClip(g_settings.enableLyricKaraoke ? lyricProgress : 0.0);
                     }
                     // Update lyric scroll state
                     if (g_settings.lyricMaxWidth > 0) {
@@ -8929,7 +9127,9 @@ static void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
         StartVizCaptureThread();
         StartVizTimer();
     }
-    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling || g_settings.lyricMaxWidth > 0) {
+    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling ||
+        g_settings.lyricMaxWidth > 0 ||
+        (g_settings.showLyric && g_settings.enableLyricKaraoke)) {
         StartScrollTimer();
     }
 

--- a/taskbar-fluent-media-player.wh.cpp
+++ b/taskbar-fluent-media-player.wh.cpp
@@ -7,7 +7,7 @@
 // @author          Salyts
 // @github          https://github.com/Salyts
 // @include         explorer.exe
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid -luser32 -lwindowsapp -lshell32 -lgdi32 -lshlwapi -lwindowscodecs -ldwmapi -lshcore -lksuser
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid -luser32 -lwindowsapp -lshell32 -lgdi32 -lshlwapi -lwindowscodecs -ldwmapi -lshcore -lksuser -lwinhttp
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -334,6 +334,26 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
       $name:ru-RU: Чувствительность (0-300)
     $name: Visualizer
     $name:ru-RU: Визуализатор
+  - LyricSettings:
+    - showLyric: false
+      $name: Show lyric
+      $description: Display lyric text next to the media player controls.
+    - lyricMargin: "4 4"
+      $name: Lyric margin (left right)
+      $description: Margin around the lyric text, left and right spacing in pixels.
+    - lyricColor: "255 255 255"
+      $name: Lyric text color (RGB)
+      $description: Text color as R G B values. Use "-1 -1 -1" for system accent color.
+    - lyricMaxWidth: "256"
+      $name: Lyric max width (px)
+      $description: Maximum width of the lyric text area. Set to 0 for no limit. When text exceeds this width, it scrolls.
+    - lyricTimeOffset: "0"
+      $name: Lyric time offset (ms)
+      $description: Adjust lyric timing. Positive = show lyrics earlier (e.g. 1000 = 1s earlier), negative = show later.
+    - hideLyricWhenNoLyrics: false
+      $name: Hide lyric when no lyrics available
+      $description: When enabled, the lyric text is hidden when no lyrics are found for the current track.
+    $name: Lyric
   $name: Main Settings
   $name:ru-RU: Основные настройки
 
@@ -987,10 +1007,13 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
 #include <winrt/Windows.Media.Control.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Graphics.Imaging.h>
+#include <winrt/Windows.Web.Http.h>
+#include <winrt/Windows.Data.Json.h>
 #include <robuffer.h>
 #include <shcore.h>
 
 #include <windows.h>
+#include <winhttp.h>
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>
@@ -1011,6 +1034,7 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
 #include <functional>
 #include <memory>
 #include <utility>
+#include <iomanip>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -1019,6 +1043,7 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
 #include <thread>
 #include <cmath>
 #include <chrono>
+#include <sstream>
 
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
@@ -1028,11 +1053,15 @@ using namespace winrt::Windows::UI::Xaml::Media::Animation;
 using namespace winrt::Windows::UI::Xaml::Input;
 using namespace winrt::Windows::Media::Control;
 using namespace winrt::Windows::Storage::Streams;
+using namespace winrt::Windows::Data::Json;
 
 enum class VizShape { Stereo, Mountain, Mirror, Wave, Breathe };
 enum class VizColorMode { Solid, DynamicAlbum, DynamicGradient, CustomGradient, Acrylic };
 enum class VizEQ { Default, Bass, Rock, Pop, Jazz, Electronic };
 enum class VizAnchor { Top, Middle, Bottom };
+
+const WCHAR *LRCLIB_API_URL = L"lrclib.net";
+const int HTTPS_PORT = INTERNET_DEFAULT_HTTPS_PORT;
 
 struct ModSettings {
     std::wstring position             = L"tray_left";
@@ -1175,6 +1204,13 @@ struct ModSettings {
     int          vizSensitivity  = 150;
     int          vizPadLeft      = 0;
     int          vizPadRight     = 0;
+    bool         showLyric              = false;
+    int          lyricMarginLeft        = 4;
+    int          lyricMarginRight       = 4;
+    std::wstring lyricColor             = L"255 255 255";
+    int          lyricMaxWidth          = 256;
+    int          lyricTimeOffset        = 0;
+    bool         hideLyricWhenNoLyrics  = false;
 };
 static ModSettings g_settings;
 
@@ -1222,6 +1258,115 @@ struct MediaButtonConfig {
 
 static std::vector<MediaButtonConfig> g_mediaButtons;
 static std::mutex g_mediaButtonsMutex;
+
+struct LyricWord {
+    std::wstring    text;
+    long            startTimeMs;
+    long            durationMs;
+};
+
+struct LyricLine {
+    std::wstring            text;
+    long                    startTimeMs;
+    long                    durationMs;
+    std::vector<LyricWord>  words;
+};
+
+struct LRCParser {
+    static long ParseTime(const std::wstring& timeStr) {
+        size_t colon = timeStr.find(L':');
+        if (colon != std::wstring::npos) {
+            std::wstring minStr = timeStr.substr(0, colon);
+            std::wstring secStr = timeStr.substr(colon + 1);
+            float m = (float)_wtof(minStr.c_str());
+            float s = (float)_wtof(secStr.c_str());
+            return (long)((m * 60.0f + s) * 1000.0f);
+        }
+        return 0;
+    }
+
+    static std::vector<LyricLine> Parse(const std::wstring& lrc, long songDuration) {
+        std::vector<LyricLine> lines;
+        std::wstringstream ss(lrc);
+        std::wstring line;
+        while (std::getline(ss, line)) {
+            if (line.empty())
+                continue;
+
+            size_t lastEnd = 0;
+            std::vector<long> timestamps;
+            while (true) {
+                size_t start = line.find(L'[', lastEnd);
+                size_t end = line.find(L']', start);
+                if (start != std::wstring::npos && end != std::wstring::npos && end > start + 1) {
+                    std::wstring timePart = line.substr(start + 1, end - start - 1);
+                    timestamps.push_back(ParseTime(timePart));
+                    lastEnd = end + 1;
+                } else
+                    break;
+            }
+
+            if (timestamps.empty())
+                continue;
+            std::wstring textPart = line.substr(lastEnd);
+
+            for (long startTime : timestamps) {
+                LyricLine l;
+                l.startTimeMs = startTime;
+
+                size_t wStart = 0;
+                while ((wStart = textPart.find(L'<', wStart)) != std::wstring::npos) {
+                    size_t wEnd = textPart.find(L'>', wStart);
+                    if (wEnd != std::wstring::npos) {
+                        LyricWord w;
+                        w.startTimeMs = ParseTime(textPart.substr(wStart + 1, wEnd - wStart - 1));
+                        size_t nextW = textPart.find(L'<', wEnd);
+                        w.text = textPart.substr(wEnd + 1, nextW - wEnd - 1);
+                        l.words.push_back(w);
+                        wStart = wEnd + 1;
+                    } else
+                        break;
+                }
+
+                if (l.words.empty()) {
+                    l.text = textPart;
+                } else {
+                    for (auto& w : l.words)
+                        l.text += w.text;
+                }
+                lines.push_back(l);
+            }
+        }
+
+        std::sort(lines.begin(), lines.end(),
+             [](const LyricLine& a, const LyricLine& b) {
+                 return a.startTimeMs < b.startTimeMs;
+             });
+
+        for (size_t i = 0; i < lines.size(); i++) {
+            if (i + 1 < lines.size()) {
+                long gap = lines[i + 1].startTimeMs - lines[i].startTimeMs;
+                lines[i].durationMs = (gap < 8000) ? gap : 5000;
+            } else {
+                lines[i].durationMs = 5000;
+            }
+
+            if (!lines[i].words.empty()) {
+                for (size_t j = 0; j < lines[i].words.size(); j++) {
+                    if (j + 1 < lines[i].words.size()) {
+                        lines[i].words[j].durationMs = lines[i].words[j + 1].startTimeMs -
+                                                       lines[i].words[j].startTimeMs;
+                    } else {
+                        lines[i].words[j].durationMs =
+                            lines[i].durationMs -
+                            (lines[i].words[j].startTimeMs - lines[i].startTimeMs);
+                    }
+                }
+            }
+        }
+        return lines;
+    }
+};
 
 static std::wstring MapFontName(const std::wstring& key) {
     if (key == L"custom") return L"";
@@ -1469,6 +1614,13 @@ static void LoadSettings() {
                      : (anchor == L"bottom") ? VizAnchor::Bottom
                                              : VizAnchor::Middle;
     }
+
+    g_settings.showLyric                = Wh_GetIntSetting(L"MainSettings.LyricSettings.showLyric") != 0;
+    g_settings.lyricColor               = Str(L"MainSettings.LyricSettings.lyricColor", L"255 255 255");
+    g_settings.lyricMaxWidth            = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricMaxWidth");
+    g_settings.lyricTimeOffset          = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricTimeOffset");
+    g_settings.hideLyricWhenNoLyrics    = Wh_GetIntSetting(L"MainSettings.LyricSettings.hideLyricWhenNoLyrics") != 0;
+    ParseMargin(L"MainSettings.LyricSettings.lyricMargin", L"4 4", g_settings.lyricMarginLeft, g_settings.lyricMarginRight);
 
     g_settings.albumArtLeftClick        = L"none";
     g_settings.albumArtRightClick       = L"none";
@@ -1726,9 +1878,12 @@ static bool RunFromWindowThread(HWND hWnd, WindowThreadProc proc, void* param) {
 struct MediaState {
     std::wstring      title;
     std::wstring      artist;
+    std::wstring      album;
     std::wstring      appUserModelId;
     bool              isPlaying     = false;
     bool              hasMedia      = false;
+    long              durationMs        = 0;
+    long              currentPositionMs = 0;
     std::vector<BYTE> thumbnailBytes;
     uint64_t          thumbnailHash = 0;
     std::vector<BYTE> appIconBytes;
@@ -1759,6 +1914,10 @@ static int g_cachedAppIconSize = -1;
 
 static std::wstring g_scrollCachedTitle;
 static std::wstring g_scrollCachedArtist;
+static std::wstring g_lyricFetchedTitle;
+static std::wstring g_lyricFetchedArtist;
+static std::vector<LyricLine> g_lyricLines;
+static std::mutex g_lyricLinesMtx;
 
 struct BlurBgCache {
     std::vector<BYTE>  blurredPixels;
@@ -2774,6 +2933,7 @@ struct TextScrollState {
 
 static TextScrollState g_titleScroll;
 static TextScrollState g_artistScroll;
+static TextScrollState g_lyricScroll;
 
 static void ResetScrollState(TextScrollState& s);
 
@@ -3978,7 +4138,7 @@ static void ScrollTimerTick(winrt::Windows::Foundation::IInspectable const&,
                              winrt::Windows::Foundation::IInspectable const&) {
     if (g_unloading || g_applyingSettings) return;
 
-    bool needsScroll = (g_titleScroll.active || g_artistScroll.active);
+    bool needsScroll = (g_titleScroll.active || g_artistScroll.active || g_lyricScroll.active);
     if (!needsScroll) return;
 
     int stepPx = std::max(1, g_settings.scrollSpeed);
@@ -3986,6 +4146,7 @@ static void ScrollTimerTick(winrt::Windows::Foundation::IInspectable const&,
 
     TickScrollState(g_titleScroll, stepPx, pauseMs, g_settings.scrollMode);
     TickScrollState(g_artistScroll, stepPx, pauseMs, g_settings.scrollMode);
+    TickScrollState(g_lyricScroll, stepPx, pauseMs, g_settings.scrollMode);
 
     UpdateScrollTransforms();
 }
@@ -4052,6 +4213,8 @@ static constexpr wchar_t kTitleScrollViewName[]  = L"FluentMedia_TitleScrollView
 static constexpr wchar_t kArtistScrollViewName[] = L"FluentMedia_ArtistScrollView";
 static constexpr wchar_t kTitleCloneName[]       = L"FluentMedia_TitleClone";
 static constexpr wchar_t kArtistCloneName[]      = L"FluentMedia_ArtistClone";
+static constexpr wchar_t kLyricScrollViewName[]  = L"FluentMedia_LyricScrollView";
+static constexpr wchar_t kLyricCloneName[]       = L"FluentMedia_LyricClone";
 static constexpr wchar_t kPanelGridName[]        = L"FluentMedia_PanelGrid";
 
 static double GetAvailableScrollTextAreaWidth() {
@@ -4126,6 +4289,24 @@ static void UpdateScrollTransforms() {
                             } else if (isLoop && name == kArtistCloneName) {
                                 double gap = g_artistScroll.textWidth + g_settings.loopGap;
                                 Canvas::SetLeft(ab, gap - g_artistScroll.offset);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (...) {}
+    }
+
+    if (g_settings.lyricMaxWidth > 0) {
+        try {
+            if (auto fe = FindChildByName(g_playerGrid, kLyricScrollViewName)) {
+                if (auto cv = fe.try_as<Canvas>()) {
+                    int n = VisualTreeHelper::GetChildrenCount(cv);
+                    for (int i = 0; i < n; i++) {
+                        auto child = VisualTreeHelper::GetChild(cv, i);
+                        if (auto tb = child.try_as<TextBlock>()) {
+                            if (tb.Name() == L"FluentMedia_Lyric") {
+                                Canvas::SetLeft(tb, -g_lyricScroll.offset);
                             }
                         }
                     }
@@ -4218,6 +4399,30 @@ static DWORD WINAPI TimerThreadProc(void*) {
                         RefreshThemeColors();
                     }
                 }, nullptr);
+            }
+        }
+
+        if (g_settings.showLyric && g_playerGrid) {
+            static auto lastLyricUpdate = std::chrono::steady_clock::now();
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastLyricUpdate).count();
+            if (elapsed >= 1000) {
+                lastLyricUpdate = now;
+                std::thread([]() {
+                    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+                    try {
+                        GlobalSystemMediaTransportControlsSession session{nullptr};
+                        { std::lock_guard<std::mutex> lk(g_sessionMtx); session = g_currentSession; }
+                        if (session) {
+                            auto timeline = session.GetTimelineProperties();
+                            auto pos = timeline.Position();
+                            long ms = static_cast<long>(pos.count() / 10000);
+                            { std::lock_guard<std::mutex> lk(g_mediaMtx); g_media.currentPositionMs = ms; }
+                        }
+                    } catch (...) {}
+                    winrt::uninit_apartment();
+                }).detach();
+                g_needsUiUpdate = true;
             }
         }
 
@@ -4852,6 +5057,342 @@ static FrameworkElement BuildVisualizerElement() {
     return vizContainer;
 }
 
+// From https://github.com/narroveseacan/windhawk-floatinglyricbar/blob/228291ed03b439567d275b9a09a51743847467fe/mods/floatinglyricbar.wh.cpp
+std::wstring URLEncode(std::wstring str) {
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, str.c_str(),
+                                          (int)str.length(), NULL, 0, NULL, NULL);
+    std::string utf8_str(size_needed, 0);
+    WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), &utf8_str[0],
+                        size_needed, NULL, NULL);
+
+    std::wstringstream ss;
+    for (unsigned char c : utf8_str) {
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            ss << (wchar_t)c;
+        } else if (c == ' ') {
+            ss << L"+";
+        } else {
+            ss << L"%" << std::hex << std::uppercase << std::setw(2) << std::setfill(L'0') << (int)c;
+        }
+    }
+    return ss.str();
+}
+
+static std::wstring HttpGet(const WCHAR* host, int port, const std::wstring& path) {
+    HINTERNET hSession = WinHttpOpen(L"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36", 
+                                     WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession) return L"";
+
+    HINTERNET hConnect = WinHttpConnect(hSession, host, port, 0);
+    if (!hConnect) { WinHttpCloseHandle(hSession); return L""; }
+
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", path.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (!hRequest) { WinHttpCloseHandle(hConnect); WinHttpCloseHandle(hSession); return L""; }
+
+    std::wstring headers = 
+        L"Origin: https://music.youtube.com\r\n"
+        L"Referer: https://music.youtube.com/\r\n"
+        L"sec-ch-ua: \"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Google Chrome\";v=\"146\"\r\n"
+        L"sec-ch-ua-mobile: ?0\r\n"
+        L"sec-ch-ua-platform: \"Windows\"\r\n"
+        L"sec-fetch-dest: empty\r\n"
+        L"sec-fetch-mode: cors\r\n"
+        L"sec-fetch-site: cross-site\r\n";
+
+    WinHttpAddRequestHeaders(hRequest, headers.c_str(), (ULONG)-1, WINHTTP_ADDREQ_FLAG_ADD);
+
+    std::wstring result;
+    if (WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0)) {
+        if (WinHttpReceiveResponse(hRequest, NULL)) {
+            DWORD dwStatusCode = 0;
+            DWORD dwSize = sizeof(dwStatusCode);
+            WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+            if (dwStatusCode == 200) {
+                std::string rawResponse;
+                DWORD dwSizeAvail = 0;
+                do {
+                    if (!WinHttpQueryDataAvailable(hRequest, &dwSizeAvail)) break;
+                    if (dwSizeAvail == 0) break;
+                    std::vector<char> buffer(dwSizeAvail);
+                    DWORD dwDownloaded = 0;
+                    if (WinHttpReadData(hRequest, buffer.data(), dwSizeAvail, &dwDownloaded)) {
+                        rawResponse.append(buffer.data(), dwDownloaded);
+                    }
+                } while (dwSizeAvail > 0);
+
+                if (!rawResponse.empty()) {
+                    int wlen = MultiByteToWideChar(CP_UTF8, 0, rawResponse.c_str(), (int)rawResponse.length(), NULL, 0);
+                    if (wlen > 0) {
+                        std::vector<wchar_t> wbuf(wlen);
+                        MultiByteToWideChar(CP_UTF8, 0, rawResponse.c_str(), (int)rawResponse.length(), wbuf.data(), wlen);
+                        result.assign(wbuf.data(), wlen);
+                    }
+                }
+            } else {
+                Wh_Log(L"HTTP GET returned error: %d", dwStatusCode);
+            }
+        }
+    }
+    WinHttpCloseHandle(hRequest);
+    WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    return result;
+}
+
+static std::wstring HttpGetNetEase(const WCHAR* host, int port, const std::wstring& path) {
+    HINTERNET hSession = WinHttpOpen(L"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36", 
+                                     WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession) return L"";
+
+    HINTERNET hConnect = WinHttpConnect(hSession, host, port, 0);
+    if (!hConnect) { WinHttpCloseHandle(hSession); return L""; }
+
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", path.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (!hRequest) { WinHttpCloseHandle(hConnect); WinHttpCloseHandle(hSession); return L""; }
+
+    std::wstring headers = 
+        L"Referer: https://music.163.com/\r\n"
+        L"Cookie: appver=1.5.0.75771; os=pc;\r\n"
+        L"Origin: https://music.163.com\r\n"
+        L"sec-ch-ua: \"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Google Chrome\";v=\"146\"\r\n"
+        L"sec-ch-ua-mobile: ?0\r\n"
+        L"sec-ch-ua-platform: \"Windows\"\r\n";
+
+    WinHttpAddRequestHeaders(hRequest, headers.c_str(), (ULONG)-1, WINHTTP_ADDREQ_FLAG_ADD);
+
+    std::wstring result;
+    if (WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0)) {
+        if (WinHttpReceiveResponse(hRequest, NULL)) {
+            DWORD dwStatusCode = 0;
+            DWORD dwSize = sizeof(dwStatusCode);
+            WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+            if (dwStatusCode == 200) {
+                std::string rawResponse;
+                DWORD dwSizeAvail = 0;
+                do {
+                    if (!WinHttpQueryDataAvailable(hRequest, &dwSizeAvail)) break;
+                    if (dwSizeAvail == 0) break;
+                    std::vector<char> buffer(dwSizeAvail);
+                    DWORD dwDownloaded = 0;
+                    if (WinHttpReadData(hRequest, buffer.data(), dwSizeAvail, &dwDownloaded)) {
+                        rawResponse.append(buffer.data(), dwDownloaded);
+                    }
+                } while (dwSizeAvail > 0);
+
+                if (!rawResponse.empty()) {
+                    int wlen = MultiByteToWideChar(CP_UTF8, 0, rawResponse.c_str(), (int)rawResponse.length(), NULL, 0);
+                    if (wlen > 0) {
+                        std::vector<wchar_t> wbuf(wlen);
+                        MultiByteToWideChar(CP_UTF8, 0, rawResponse.c_str(), (int)rawResponse.length(), wbuf.data(), wlen);
+                        result.assign(wbuf.data(), wlen);
+                    }
+                }
+            } else {
+                Wh_Log(L"NetEase API returned error: %d", dwStatusCode);
+            }
+        }
+    }
+    WinHttpCloseHandle(hRequest);
+    WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    return result;
+}
+
+static std::wstring CleanMediaString(std::wstring str) {
+    size_t pOpen = str.find(L'(');
+    if (pOpen != std::wstring::npos) str = str.substr(0, pOpen);
+
+    size_t bOpen = str.find(L'[');
+    if (bOpen != std::wstring::npos) str = str.substr(0, bOpen);
+
+    std::wstring lowerStr = str;
+    std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::towlower);
+
+    const wchar_t* tags[] = {
+        L" feat", L" ft.", L" ft ", L" featuring", L" - remastered", 
+        L" - single", L" - radio edit", L" - stereo"
+    };
+
+    for (const wchar_t* tag : tags) {
+        size_t pos = lowerStr.find(tag);
+        if (pos != std::wstring::npos) {
+            str = str.substr(0, pos);
+            lowerStr = lowerStr.substr(0, pos);
+        }
+    }
+
+    size_t last = str.find_last_not_of(L" \t\r\n");
+    if (last != std::wstring::npos) {
+        str = str.substr(0, last + 1);
+    }
+    return str;
+}
+
+static bool FetchFromNetEase(const std::wstring& title, const std::wstring& artist,
+                             const std::wstring& album, long durationMs,
+                             std::vector<LyricLine>& outLyrics) {
+    std::wstring searchPath = L"/api/search/get/web?s=" + URLEncode(title + L" " + artist) +
+                         L"&type=1&offset=0&total=true&limit=1";
+    std::wstring searchJson = HttpGetNetEase(L"music.163.com", INTERNET_DEFAULT_HTTPS_PORT, searchPath);
+    if (searchJson.empty())
+        return false;
+
+    try {
+        winrt::Windows::Data::Json::JsonObject obj = winrt::Windows::Data::Json::JsonObject::Parse(searchJson);
+        if (!obj.HasKey(L"result")) return false;
+        winrt::Windows::Data::Json::JsonObject resultObj = obj.GetNamedObject(L"result");
+
+        if (!resultObj.HasKey(L"songs")) return false;
+        winrt::Windows::Data::Json::JsonArray songsArr = resultObj.GetNamedArray(L"songs");
+
+        if (songsArr.Size() == 0) return false;
+        winrt::Windows::Data::Json::JsonObject firstSong = songsArr.GetAt(0).GetObject();
+        double songId = firstSong.GetNamedNumber(L"id");
+
+        std::wstring lyricPath = L"/api/song/lyric?id=" + std::to_wstring((long long)songId) + L"&lv=1&kv=1&tv=-1";
+        std::wstring lyricJson = HttpGetNetEase(L"music.163.com", INTERNET_DEFAULT_HTTPS_PORT, lyricPath);
+        if (lyricJson.empty())
+            return false;
+
+        winrt::Windows::Data::Json::JsonObject lObj = winrt::Windows::Data::Json::JsonObject::Parse(lyricJson);
+        if (lObj.HasKey(L"lrc")) {
+            winrt::Windows::Data::Json::JsonObject lrcObj = lObj.GetNamedObject(L"lrc");
+            std::wstring lrc = lrcObj.GetNamedString(L"lyric").c_str();
+
+            auto ReplaceAll = [](std::wstring& s, const std::wstring& from, const std::wstring& to) {
+                size_t pos = 0;
+                while ((pos = s.find(from, pos)) != std::wstring::npos) {
+                    s.replace(pos, from.length(), to);
+                    pos += to.length();
+                }
+            };
+            ReplaceAll(lrc, L"\\n", L"\n");
+            ReplaceAll(lrc, L"\\\"", L"\"");
+            ReplaceAll(lrc, L"\\r", L"");
+
+            outLyrics = LRCParser::Parse(lrc, durationMs);
+
+            for (auto& line : outLyrics) {
+                if (line.text.size() > 4 && line.text[0] == L'[') {
+                    size_t br = line.text.find(L']');
+                    if (br != std::wstring::npos && br < 15) {
+                        line.text.erase(0, br + 1);
+                    }
+                }
+            }
+
+            return !outLyrics.empty();
+        }
+    } catch (...) {
+    }
+    return false;
+}
+
+bool FetchFromLRCLib(std::wstring title, std::wstring artist, std::wstring album,
+                     long durationMs, std::vector<LyricLine> &outLyrics) {
+    std::wstring path = L"/api/get?track_name=" + URLEncode(title) + L"&artist_name=" +
+                        URLEncode(artist);
+    if (!album.empty())
+        path += L"&album_name=" + URLEncode(album);
+    if (durationMs > 0)
+        path += L"&duration=" + std::to_wstring(durationMs / 1000);
+
+    std::wstring json = HttpGet(LRCLIB_API_URL, HTTPS_PORT, path); // No JWT for LRCLib
+
+    // Helper function to safely extract LRC from a JSON object
+    auto ExtractLRC = [&](JsonObject obj) -> bool {
+        if (obj.HasKey(L"syncedLyrics") && obj.GetNamedValue(L"syncedLyrics").ValueType() == JsonValueType::String) {
+            std::wstring lrc = obj.GetNamedString(L"syncedLyrics").c_str();
+            if (!lrc.empty()) {
+                auto ReplaceAll = [](std::wstring &s, const std::wstring &from, const std::wstring &to) {
+                    size_t pos = 0;
+                    while ((pos = s.find(from, pos)) != std::wstring::npos) {
+                        s.replace(pos, from.length(), to);
+                        pos += to.length();
+                    }
+                };
+                ReplaceAll(lrc, L"\\n", L"\n");
+                ReplaceAll(lrc, L"\\\"", L"\"");
+                ReplaceAll(lrc, L"\\r", L"");
+
+                outLyrics = LRCParser::Parse(lrc, durationMs);
+                return !outLyrics.empty();
+            }
+        }
+        return false;
+    };
+
+    // 1. Try Exact Match First
+    try {
+        if (!json.empty()) {
+            JsonObject obj = JsonObject::Parse(json);
+            if (ExtractLRC(obj))
+                return true;
+        }
+    }
+    catch (...) {}
+
+    // 2. Fallback to Broad Search Array
+    std::wstring searchPath = L"/api/search?q=" + URLEncode(artist + L" " + title);
+    json = HttpGet(LRCLIB_API_URL, HTTPS_PORT, searchPath);
+    if (json.empty() || json.length() < 10)
+        return false;
+
+    try {
+        JsonArray arr = JsonArray::Parse(json);
+        // Iterate through search results and grab the first one that actually contains synced lyrics
+        for (uint32_t i = 0; i < arr.Size(); i++) {
+            JsonObject obj = arr.GetAt(i).GetObject();
+            if (ExtractLRC(obj)) {
+                Wh_Log(L"LRCLib search fallback succeeded on array index %d", i);
+                return true;
+            }
+        }
+    }
+    catch (...) {}
+
+    return false;
+}
+
+static void FetchLyrics(const std::wstring& title, const std::wstring& artist,
+                        const std::wstring& album, long durationMs) {
+    std::vector<LyricLine> lines;
+    bool found = false;
+
+    std::wstring cleanTitle = CleanMediaString(title);
+    std::wstring cleanAlbum = CleanMediaString(album);
+
+    if (FetchFromNetEase(cleanTitle, artist, cleanAlbum, durationMs, lines)) {
+        Wh_Log(L"Lyrics found from NetEase");
+        found = true;
+    }
+    else if (FetchFromLRCLib(cleanTitle, artist,cleanAlbum, durationMs, lines)) {
+        Wh_Log(L"Lyrics found from LRCLib");
+        found = true;
+    }
+
+    if (!found) {
+        Wh_Log(L"No lyrics found for %s", title.c_str());
+        return;
+    }
+
+    Wh_Log(L"===== Lyrics for %s - %s (%d lines) =====", title.c_str(), artist.c_str(), (int)lines.size());
+    for (size_t i = 0; i < lines.size(); i++) {
+        auto& line = lines[i];
+        long mins = line.startTimeMs / 60000;
+        long secs = (line.startTimeMs % 60000) / 1000;
+        Wh_Log(L"[%02ld:%02ld] %s", mins, secs, line.text.c_str());
+    }
+    Wh_Log(L"===== End Lyrics =====");
+    
+    {
+        std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
+        g_lyricLines = std::move(lines);
+    }
+}
+
 static void StartTimerThread() {
     if (g_timerThread) return;
     g_timerStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
@@ -4864,7 +5405,7 @@ static void StartTimerThread() {
         g_timerUpdateEvent = nullptr;
     }
 
-    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling) {
+    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling || g_settings.lyricMaxWidth > 0) {
         StartScrollTimer();
     }
 }
@@ -5830,7 +6371,7 @@ static Grid BuildPlayerGrid() {
             textStack.Orientation(Orientation::Vertical);
             textStack.VerticalAlignment(VerticalAlignment::Center);
 
-            if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling) {
+            if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling || g_settings.lyricMaxWidth > 0) {
                 textStack.HorizontalAlignment(HorizontalAlignment::Stretch);
             } else {
                 textStack.HorizontalAlignment(g_settings.mirrorLayout ? HorizontalAlignment::Right : HorizontalAlignment::Left);
@@ -6184,6 +6725,61 @@ static Grid BuildPlayerGrid() {
                 }
             } catch (...) {
                 Wh_Log(L"BuildPlayerGrid: Exception adding inline visualizer");
+            }
+        }
+
+        if (g_settings.showLyric) {
+            try {
+                TextBlock lyricBlock;
+                lyricBlock.Name(L"FluentMedia_Lyric");
+                lyricBlock.Text(L"🎵🎵🎵");
+                lyricBlock.VerticalAlignment(VerticalAlignment::Center);
+                lyricBlock.Foreground(MakeBrush(ParseColorWithThemeSupport(g_settings.lyricColor, 255)));
+                lyricBlock.FontSize(12);
+
+                if (g_settings.lyricMaxWidth > 0) {
+                    lyricBlock.Margin({0, 0, 0, 0});
+                    Canvas lyricScrollView;
+                    lyricScrollView.Name(kLyricScrollViewName);
+                    lyricScrollView.VerticalAlignment(VerticalAlignment::Center);
+                    lyricScrollView.Margin({(double)g_settings.lyricMarginLeft, 0, (double)g_settings.lyricMarginRight, 0});
+                    lyricScrollView.Width((double)g_settings.lyricMaxWidth);
+
+                    lyricBlock.TextTrimming(TextTrimming::None);
+                    lyricBlock.TextWrapping(TextWrapping::NoWrap);
+                    Canvas::SetLeft(lyricBlock, 0.0);
+                    Canvas::SetTop(lyricBlock, 0.0);
+                    lyricScrollView.Children().Append(lyricBlock);
+
+                    {
+                        auto geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
+                        lyricScrollView.Clip(geo);
+                        lyricBlock.SizeChanged([lyricScrollView, geo](winrt::Windows::Foundation::IInspectable const&, winrt::Windows::UI::Xaml::SizeChangedEventArgs const& e) mutable {
+                            try {
+                                double h = e.NewSize().Height;
+                                if (h < 1.0) h = 16.0;
+                                double w = lyricScrollView.Width();
+                                lyricScrollView.Height(h);
+                                geo.Rect({0, 0, (float)w, (float)h});
+                            } catch (...) {}
+                        });
+                    }
+
+                    auto lyricCol = ColumnDefinition();
+                    lyricCol.Width({1.0, GridUnitType::Auto});
+                    panel.ColumnDefinitions().Append(lyricCol);
+                    Grid::SetColumn(lyricScrollView, (int)panel.ColumnDefinitions().Size() - 1);
+                    panel.Children().Append(lyricScrollView);
+                } else {
+                    lyricBlock.Margin({(double)g_settings.lyricMarginLeft, 0, (double)g_settings.lyricMarginRight, 0});
+                    auto lyricCol = ColumnDefinition();
+                    lyricCol.Width({1.0, GridUnitType::Auto});
+                    panel.ColumnDefinitions().Append(lyricCol);
+                    Grid::SetColumn(lyricBlock, (int)panel.ColumnDefinitions().Size() - 1);
+                    panel.Children().Append(lyricBlock);
+                }
+            } catch (...) {
+                Wh_Log(L"BuildPlayerGrid: Exception adding lyric text");
             }
         }
 
@@ -7976,6 +8572,92 @@ static void RefreshPlayerContents() {
                 }
             }
     }
+
+    if (g_settings.showLyric) {
+        try {
+            if (auto lyricFe = FindChildByName(g_playerGrid, L"FluentMedia_Lyric")) {
+                if (auto lyricBlock = lyricFe.try_as<TextBlock>()) {
+                    std::wstring timeText = L"🎵🎵🎵";
+                    long long currentMs = 0;
+                    {
+                        std::lock_guard<std::mutex> lk(g_mediaMtx);
+                        currentMs = g_media.currentPositionMs + g_settings.lyricTimeOffset;
+                    }
+                    {
+                        std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
+                        for (const auto& line : g_lyricLines) {
+                            if (currentMs >= line.startTimeMs && currentMs < line.startTimeMs + line.durationMs) {
+                                if (!line.text.empty()) {
+                                    timeText = line.text;
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    if (timeText == L"🎵🎵🎵" && g_settings.hideLyricWhenNoLyrics) {
+                        if (g_settings.lyricMaxWidth > 0) {
+                            if (auto cv = FindChildByName(g_playerGrid, kLyricScrollViewName)) {
+                                if (cv.Visibility() != Visibility::Collapsed)
+                                    cv.Visibility(Visibility::Collapsed);
+                            }
+                        } else {
+                            if (lyricBlock.Visibility() != Visibility::Collapsed)
+                                lyricBlock.Visibility(Visibility::Collapsed);
+                        }
+                    } else {
+                        if (g_settings.lyricMaxWidth > 0) {
+                            if (auto cv = FindChildByName(g_playerGrid, kLyricScrollViewName)) {
+                                if (cv.Visibility() != Visibility::Visible)
+                                    cv.Visibility(Visibility::Visible);
+                            }
+                        } else {
+                            if (lyricBlock.Visibility() != Visibility::Visible)
+                                lyricBlock.Visibility(Visibility::Visible);
+                        }
+                        if (timeText != lyricBlock.Text().c_str()) {
+                            lyricBlock.Text(timeText);
+                        }
+                    }
+                    // Update lyric scroll state
+                    if (g_settings.lyricMaxWidth > 0) {
+                        try {
+                            g_lyricScroll.textWidth = lyricBlock.ActualWidth();
+                            g_lyricScroll.viewWidth = (double)g_settings.lyricMaxWidth;
+                            g_lyricScroll.active = (g_lyricScroll.textWidth > g_lyricScroll.viewWidth && g_lyricScroll.viewWidth > 0);
+                            if (!g_lyricScroll.active) {
+                                g_lyricScroll.offset = 0;
+                            }
+                        } catch (...) {}
+                    }
+                }
+            }
+        } catch (...) {
+            Wh_Log(L"RefreshPlayerContents: Exception updating lyric text");
+        }
+    }
+    if (g_settings.showLyric && !g_cachedAlbumTitle.empty()) {
+        std::wstring fetchTitle = g_cachedAlbumTitle;
+        std::wstring fetchArtist = g_cachedAlbumArtist;
+        std::wstring fetchAlbum;
+        long fetchDuration = 0;
+        {
+            std::lock_guard<std::mutex> lk(g_mediaMtx);
+            fetchAlbum = g_media.album;
+            fetchDuration = g_media.durationMs;
+        }
+        if (fetchTitle != g_lyricFetchedTitle || fetchArtist != g_lyricFetchedArtist) {
+            g_lyricFetchedTitle = fetchTitle;
+            g_lyricFetchedArtist = fetchArtist;
+            {
+                std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
+                g_lyricLines.clear();
+            }
+            Wh_Log(L"RefreshPlayerContents: Fetching lyrics for '%s' - '%s'", fetchTitle.c_str(), fetchArtist.c_str());
+            std::thread([fetchTitle, fetchArtist, fetchAlbum, fetchDuration]() {
+                FetchLyrics(fetchTitle, fetchArtist, fetchAlbum, fetchDuration);
+            }).detach();
+        }
+    }
 }
 
 static bool IsFullscreenActive() {
@@ -8247,7 +8929,7 @@ static void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
         StartVizCaptureThread();
         StartVizTimer();
     }
-    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling) {
+    if (g_settings.enableTitleScrolling || g_settings.enableArtistScrolling || g_settings.lyricMaxWidth > 0) {
         StartScrollTimer();
     }
 

--- a/taskbar-fluent-media-player.wh.cpp
+++ b/taskbar-fluent-media-player.wh.cpp
@@ -356,9 +356,22 @@ If you encounter any issues, bugs, or have suggestions for new features, please 
     - lyricTimeOffset: "0"
       $name: Lyric time offset (ms)
       $description: Adjust lyric timing. Positive = show lyrics earlier (e.g. 1000 = 1s earlier), negative = show later.
+    - lyricTransitionEffect: "fade"
+      $name: Lyric transition effect
+      $description: Animation used when switching to the next lyric line.
+      $options:
+      - "none": "None"
+      - "fade": "Fade in/out"
+      - "scroll_up": "Scroll up"
+      - "scroll_down": "Scroll down"
+      - "scroll_left": "Scroll left"
+      - "scroll_right": "Scroll right"
     - hideLyricWhenNoLyrics: false
       $name: Hide lyric when no lyrics available
       $description: When enabled, the lyric text is hidden when no lyrics are found for the current track.
+    - lyricHideDelay: "1500"
+      $name: Lyric hide delay (ms)
+      $description: Keep showing the last lyric line for this many milliseconds before hiding when no current lyric is available.
     $name: Lyric
   $name: Main Settings
   $name:ru-RU: Основные настройки
@@ -1218,7 +1231,9 @@ struct ModSettings {
     std::wstring lyricHighlightColor    = L"30 215 96";
     int          lyricMaxWidth          = 256;
     int          lyricTimeOffset        = 0;
+    std::wstring lyricTransitionEffect  = L"fade";
     bool         hideLyricWhenNoLyrics  = false;
+    int          lyricHideDelay         = 1500;
 };
 static ModSettings g_settings;
 
@@ -1346,7 +1361,47 @@ struct LRCParser {
             }
         }
 
-        std::sort(lines.begin(), lines.end(),
+        std::stable_sort(lines.begin(), lines.end(),
+             [](const LyricLine& a, const LyricLine& b) {
+                 return a.startTimeMs < b.startTimeMs;
+             });
+
+        for (size_t i = 0; i < lines.size();) {
+            size_t groupEnd = i + 1;
+            while (groupEnd < lines.size() &&
+                   lines[groupEnd].startTimeMs == lines[i].startTimeMs) {
+                groupEnd++;
+            }
+
+            if (groupEnd - i > 1) {
+                long groupStart = lines[i].startTimeMs;
+                long nextStart = (groupEnd < lines.size()) ? lines[groupEnd].startTimeMs
+                                                           : groupStart + 5000;
+                long groupDuration = nextStart - groupStart;
+                if (groupDuration <= 0) groupDuration = 5000;
+
+                long step = std::max(1L, groupDuration / (long)(groupEnd - i));
+                for (size_t j = i; j < groupEnd; j++) {
+                    lines[j].startTimeMs = groupStart + step * (long)(j - i);
+                    if (j + 1 < groupEnd) {
+                        lines[j].durationMs = step;
+                    } else {
+                        lines[j].durationMs = std::max(1L, nextStart - lines[j].startTimeMs);
+                    }
+                }
+            } else {
+                if (i + 1 < lines.size()) {
+                    long gap = lines[i + 1].startTimeMs - lines[i].startTimeMs;
+                    lines[i].durationMs = (gap < 8000) ? gap : 5000;
+                } else {
+                    lines[i].durationMs = 5000;
+                }
+            }
+
+            i = groupEnd;
+        }
+
+        std::stable_sort(lines.begin(), lines.end(),
              [](const LyricLine& a, const LyricLine& b) {
                  return a.startTimeMs < b.startTimeMs;
              });
@@ -1354,9 +1409,9 @@ struct LRCParser {
         for (size_t i = 0; i < lines.size(); i++) {
             if (i + 1 < lines.size()) {
                 long gap = lines[i + 1].startTimeMs - lines[i].startTimeMs;
-                lines[i].durationMs = (gap < 8000) ? gap : 5000;
-            } else {
-                lines[i].durationMs = 5000;
+                if (gap > 0 && lines[i].durationMs > gap) {
+                    lines[i].durationMs = gap;
+                }
             }
 
             if (!lines[i].words.empty()) {
@@ -1369,6 +1424,7 @@ struct LRCParser {
                             lines[i].durationMs -
                             (lines[i].words[j].startTimeMs - lines[i].startTimeMs);
                     }
+                    lines[i].words[j].durationMs = std::max(1L, lines[i].words[j].durationMs);
                 }
             }
         }
@@ -1629,7 +1685,16 @@ static void LoadSettings() {
     g_settings.lyricHighlightColor      = Str(L"MainSettings.LyricSettings.lyricHighlightColor", L"30 215 96");
     g_settings.lyricMaxWidth            = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricMaxWidth");
     g_settings.lyricTimeOffset          = Wh_GetIntSetting(L"MainSettings.LyricSettings.lyricTimeOffset");
+    g_settings.lyricTransitionEffect    = Str(L"MainSettings.LyricSettings.lyricTransitionEffect", L"fade");
+    if (g_settings.lyricTransitionEffect != L"none" &&
+        g_settings.lyricTransitionEffect != L"scroll_up" &&
+        g_settings.lyricTransitionEffect != L"scroll_down" &&
+        g_settings.lyricTransitionEffect != L"scroll_left" &&
+        g_settings.lyricTransitionEffect != L"scroll_right") {
+        g_settings.lyricTransitionEffect = L"fade";
+    }
     g_settings.hideLyricWhenNoLyrics    = Wh_GetIntSetting(L"MainSettings.LyricSettings.hideLyricWhenNoLyrics") != 0;
+    g_settings.lyricHideDelay           = Int(L"MainSettings.LyricSettings.lyricHideDelay", 0, 30000, 1500);
     ParseMargin(L"MainSettings.LyricSettings.lyricMargin", L"4 4", g_settings.lyricMarginLeft, g_settings.lyricMarginRight);
 
     g_settings.albumArtLeftClick        = L"none";
@@ -1928,6 +1993,11 @@ static std::wstring g_lyricFetchedTitle;
 static std::wstring g_lyricFetchedArtist;
 static std::vector<LyricLine> g_lyricLines;
 static std::mutex g_lyricLinesMtx;
+static std::wstring g_lastLyricDisplayText;
+static bool g_hasLastLyricDisplay = false;
+static bool g_lyricDisplayHidden = true;
+static std::chrono::steady_clock::time_point g_lastLyricMatchTime = std::chrono::steady_clock::now();
+static std::mutex g_lyricDisplayStateMtx;
 
 struct BlurBgCache {
     std::vector<BYTE>  blurredPixels;
@@ -4235,6 +4305,10 @@ static constexpr wchar_t kLyricBaseName[]        = L"FluentMedia_Lyric";
 static constexpr wchar_t kLyricHighlightName[]   = L"FluentMedia_LyricHighlight";
 static constexpr wchar_t kPanelGridName[]        = L"FluentMedia_PanelGrid";
 
+static void ApplyLyricHighlightClip(TextBlock const& highlightBlock,
+                                    double progress,
+                                    double fallbackWidth = 0.0);
+
 static double GetAvailableScrollTextAreaWidth() {
     try {
         if (g_settings.playerMaxWidth <= 0) return 0.0;
@@ -4337,24 +4411,367 @@ static void UpdateScrollTransforms() {
 static void UpdateLyricHighlightClip(double progress) {
     if (!g_playerGrid) return;
 
-    progress = std::clamp(progress, 0.0, 1.0);
-
     try {
         if (auto fe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
             if (auto highlightBlock = fe.try_as<TextBlock>()) {
-                double width = highlightBlock.ActualWidth();
-                double height = highlightBlock.ActualHeight();
-                if (height < 1.0) height = 16.0;
-
-                auto geo = highlightBlock.Clip().try_as<winrt::Windows::UI::Xaml::Media::RectangleGeometry>();
-                if (!geo) {
-                    geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
-                    highlightBlock.Clip(geo);
-                }
-                geo.Rect({0, 0, (float)(width * progress), (float)height});
+                ApplyLyricHighlightClip(highlightBlock, progress);
             }
         }
     } catch (...) {}
+}
+
+static void ApplyLyricHighlightClip(TextBlock const& highlightBlock,
+                                    double progress,
+                                    double fallbackWidth) {
+    if (!highlightBlock) return;
+
+    progress = std::clamp(progress, 0.0, 1.0);
+
+    try {
+        double width = highlightBlock.ActualWidth();
+        if (width < 1.0) width = fallbackWidth;
+        if (width < 1.0) width = 4096.0;
+
+        double height = highlightBlock.ActualHeight();
+        if (height < 1.0) height = 16.0;
+
+        auto geo = highlightBlock.Clip().try_as<winrt::Windows::UI::Xaml::Media::RectangleGeometry>();
+        if (!geo) {
+            geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
+            highlightBlock.Clip(geo);
+        }
+        geo.Rect({0, 0, (float)(width * progress), (float)height});
+    } catch (...) {}
+}
+
+static void AppendDoubleAnimation(Storyboard& sb,
+                                  DependencyObject const& target,
+                                  const wchar_t* propertyPath,
+                                  double from,
+                                  double to,
+                                  int durationMs) {
+    DoubleAnimation anim;
+    anim.EnableDependentAnimation(true);
+    anim.From(winrt::box_value(from).as<winrt::Windows::Foundation::IReference<double>>());
+    anim.To(winrt::box_value(to).as<winrt::Windows::Foundation::IReference<double>>());
+    anim.Duration(winrt::Windows::UI::Xaml::Duration{
+        winrt::Windows::Foundation::TimeSpan{std::chrono::milliseconds(durationMs)}
+    });
+    Storyboard::SetTarget(anim, target);
+    Storyboard::SetTargetProperty(anim, winrt::hstring(propertyPath));
+    sb.Children().Append(anim);
+}
+
+static TextBlock CloneLyricTextBlock(TextBlock const& source, const wchar_t* name) {
+    TextBlock clone;
+    clone.Name(name);
+    clone.Text(source.Text());
+    clone.VerticalAlignment(source.VerticalAlignment());
+    clone.HorizontalAlignment(source.HorizontalAlignment());
+    clone.Foreground(source.Foreground());
+    clone.FontSize(source.FontSize());
+    clone.FontFamily(source.FontFamily());
+    clone.FontWeight(source.FontWeight());
+    clone.FontStyle(source.FontStyle());
+    clone.TextTrimming(source.TextTrimming());
+    clone.TextWrapping(source.TextWrapping());
+    clone.Margin(source.Margin());
+    clone.Opacity(source.Opacity());
+    clone.Visibility(source.Visibility());
+    clone.IsHitTestVisible(false);
+    clone.RenderTransform(TranslateTransform());
+
+    return clone;
+}
+
+static Grid MakeLyricTransitionGroup(TextBlock const& baseSource,
+                                     TextBlock const& highlightSource,
+                                     const wchar_t* name,
+                                     const std::wstring& text,
+                                     bool includeHighlight,
+                                     bool useHighlightColorForBase,
+                                     double highlightProgress,
+                                     double fallbackHighlightWidth) {
+    Grid group;
+    group.Name(name);
+    group.IsHitTestVisible(false);
+    group.RenderTransform(TranslateTransform());
+
+    TextBlock baseClone = CloneLyricTextBlock(baseSource, L"FluentMedia_LyricTransitionBase");
+    baseClone.Text(text);
+    if (useHighlightColorForBase) {
+        baseClone.Foreground(MakeBrush(ParseColorWithThemeSupport(g_settings.lyricHighlightColor, 255)));
+    }
+    group.Children().Append(baseClone);
+
+    if (includeHighlight && highlightSource) {
+        TextBlock highlightClone = CloneLyricTextBlock(highlightSource, L"FluentMedia_LyricTransitionHighlight");
+        highlightClone.Text(text);
+        highlightClone.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+        ApplyLyricHighlightClip(highlightClone, highlightProgress, fallbackHighlightWidth);
+        group.Children().Append(highlightClone);
+    }
+
+    return group;
+}
+
+static void RemovePanelChild(Panel const& panel, UIElement const& child) {
+    try {
+        uint32_t index = 0;
+        if (panel.Children().IndexOf(child, index)) {
+            panel.Children().RemoveAt(index);
+        }
+    } catch (...) {}
+}
+
+static void SetLyricContainerVisible(bool visible) {
+    if (!g_playerGrid) return;
+
+    Visibility visibility = visible ? Visibility::Visible : Visibility::Collapsed;
+    try {
+        if (g_settings.lyricMaxWidth > 0) {
+            if (auto cv = FindChildByName(g_playerGrid, kLyricScrollViewName)) {
+                if (cv.Visibility() != visibility) {
+                    cv.Visibility(visibility);
+                }
+            }
+        } else {
+            if (auto root = FindChildByName(g_playerGrid, kLyricRootName)) {
+                if (root.Visibility() != visibility) {
+                    root.Visibility(visibility);
+                }
+            }
+        }
+    } catch (...) {}
+}
+
+static void HideLyricDisplay() {
+    SetLyricContainerVisible(false);
+    std::lock_guard<std::mutex> lk(g_lyricDisplayStateMtx);
+    g_lyricDisplayHidden = true;
+}
+
+static void SetLyricTextWithTransition(const std::wstring& text, double progress) {
+    if (!g_playerGrid) return;
+
+    auto baseFe = FindChildByName(g_playerGrid, kLyricBaseName);
+    auto baseBlock = baseFe.try_as<TextBlock>();
+    if (!baseBlock) return;
+
+    if (text == baseBlock.Text().c_str()) {
+        bool wasHidden = false;
+        {
+            std::lock_guard<std::mutex> lk(g_lyricDisplayStateMtx);
+            wasHidden = g_lyricDisplayHidden;
+            g_lyricDisplayHidden = false;
+        }
+        if (wasHidden) {
+            SetLyricContainerVisible(true);
+        }
+        if (auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
+            if (auto hiBlock = hiFe.try_as<TextBlock>()) {
+                ApplyLyricHighlightClip(hiBlock, progress);
+            }
+        }
+        return;
+    }
+
+    auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName);
+    auto hiBlock = hiFe.try_as<TextBlock>();
+
+    auto parentObj = VisualTreeHelper::GetParent(baseBlock);
+    auto parentPanel = parentObj.try_as<Panel>();
+    std::wstring oldText = baseBlock.Text().c_str();
+    std::wstring effect = g_settings.lyricTransitionEffect;
+    bool wasHidden = false;
+    {
+        std::lock_guard<std::mutex> lk(g_lyricDisplayStateMtx);
+        wasHidden = g_lyricDisplayHidden;
+        g_lyricDisplayHidden = false;
+    }
+
+    SetLyricContainerVisible(true);
+
+    baseBlock.Text(text);
+    baseBlock.Opacity(1.0);
+    baseBlock.RenderTransform(TranslateTransform());
+
+    if (hiBlock) {
+        hiBlock.Text(text);
+        hiBlock.Opacity(1.0);
+        hiBlock.RenderTransform(TranslateTransform());
+        hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+        ApplyLyricHighlightClip(hiBlock, progress);
+    }
+
+    if (effect == L"none" || !parentPanel || oldText.empty() || wasHidden) {
+        return;
+    }
+
+    const int durationMs = (effect == L"fade") ? 120 : 220;
+    double width = std::max(baseBlock.ActualWidth(), 1.0);
+    double height = std::max(baseBlock.ActualHeight(), 16.0);
+    double verticalDistance = height + 4.0;
+    if (g_settings.lyricMaxWidth > 0) {
+        width = std::max(width, (double)g_settings.lyricMaxWidth);
+    }
+
+    bool isScrollEffect = (effect == L"scroll_up" || effect == L"scroll_down" ||
+                           effect == L"scroll_left" || effect == L"scroll_right");
+    if (isScrollEffect) {
+        Grid oldGroup = MakeLyricTransitionGroup(baseBlock, hiBlock,
+                                                 L"FluentMedia_LyricOldGroup",
+                                                 oldText, false, true, 1.0, width);
+        Grid newGroup = MakeLyricTransitionGroup(baseBlock, hiBlock,
+                                                 L"FluentMedia_LyricNewGroup",
+                                                 text, hiBlock != nullptr, false, progress, width);
+
+        parentPanel.Children().Append(oldGroup);
+        parentPanel.Children().Append(newGroup);
+
+        if (parentPanel.try_as<Canvas>()) {
+            double baseLeft = Canvas::GetLeft(baseBlock);
+            double baseTop = Canvas::GetTop(baseBlock);
+            if (std::isnan(baseLeft)) baseLeft = 0.0;
+            if (std::isnan(baseTop)) baseTop = 0.0;
+            Canvas::SetLeft(oldGroup, baseLeft);
+            Canvas::SetTop(oldGroup, baseTop);
+            Canvas::SetLeft(newGroup, baseLeft);
+            Canvas::SetTop(newGroup, baseTop);
+        }
+
+        baseBlock.Visibility(Visibility::Collapsed);
+        if (hiBlock) hiBlock.Visibility(Visibility::Collapsed);
+
+        auto oldGroupTransform = TranslateTransform();
+        auto newGroupTransform = TranslateTransform();
+        oldGroup.RenderTransform(oldGroupTransform);
+        newGroup.RenderTransform(newGroupTransform);
+
+        Storyboard sb;
+        if (effect == L"scroll_up") {
+            AppendDoubleAnimation(sb, oldGroupTransform, L"Y", 0.0, -verticalDistance, durationMs);
+            AppendDoubleAnimation(sb, newGroupTransform, L"Y", verticalDistance, 0.0, durationMs);
+        } else if (effect == L"scroll_down") {
+            AppendDoubleAnimation(sb, oldGroupTransform, L"Y", 0.0, verticalDistance, durationMs);
+            AppendDoubleAnimation(sb, newGroupTransform, L"Y", -verticalDistance, 0.0, durationMs);
+        } else if (effect == L"scroll_left") {
+            AppendDoubleAnimation(sb, oldGroupTransform, L"X", 0.0, -width, durationMs);
+            AppendDoubleAnimation(sb, newGroupTransform, L"X", width, 0.0, durationMs);
+        } else {
+            AppendDoubleAnimation(sb, oldGroupTransform, L"X", 0.0, width, durationMs);
+            AppendDoubleAnimation(sb, newGroupTransform, L"X", -width, 0.0, durationMs);
+        }
+
+        auto finishScrollTransition = [parentPanel, oldGroup, newGroup, baseBlock, hiBlock]() {
+            try {
+                RemovePanelChild(parentPanel, oldGroup);
+                RemovePanelChild(parentPanel, newGroup);
+                baseBlock.Visibility(Visibility::Visible);
+                baseBlock.Opacity(1.0);
+                baseBlock.RenderTransform(TranslateTransform());
+                if (hiBlock) {
+                    hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+                    hiBlock.Opacity(1.0);
+                    hiBlock.RenderTransform(TranslateTransform());
+                }
+            } catch (...) {}
+        };
+
+        sb.Completed([finishScrollTransition](auto const&, auto const&) {
+            finishScrollTransition();
+        });
+
+        try {
+            sb.Begin();
+        } catch (...) {
+            finishScrollTransition();
+        }
+
+        return;
+    }
+
+    TextBlock oldBase = CloneLyricTextBlock(baseBlock, kLyricCloneName);
+    oldBase.Text(oldText);
+    TextBlock oldHi{nullptr};
+    if (hiBlock && hiBlock.Visibility() == Visibility::Visible) {
+        oldHi = CloneLyricTextBlock(hiBlock, L"FluentMedia_LyricHighlightClone");
+        oldHi.Text(oldText);
+        ApplyLyricHighlightClip(oldHi, 1.0, width);
+    }
+
+    parentPanel.Children().Append(oldBase);
+    if (oldHi) parentPanel.Children().Append(oldHi);
+    if (parentPanel.try_as<Canvas>()) {
+        double baseLeft = Canvas::GetLeft(baseBlock);
+        double baseTop = Canvas::GetTop(baseBlock);
+        if (std::isnan(baseLeft)) baseLeft = 0.0;
+        if (std::isnan(baseTop)) baseTop = 0.0;
+        Canvas::SetLeft(oldBase, baseLeft);
+        Canvas::SetTop(oldBase, baseTop);
+        if (oldHi) {
+            double hiLeft = hiBlock ? Canvas::GetLeft(hiBlock) : baseLeft;
+            double hiTop = hiBlock ? Canvas::GetTop(hiBlock) : baseTop;
+            if (std::isnan(hiLeft)) hiLeft = baseLeft;
+            if (std::isnan(hiTop)) hiTop = baseTop;
+            Canvas::SetLeft(oldHi, hiLeft);
+            Canvas::SetTop(oldHi, hiTop);
+        }
+    }
+
+    auto newBaseTransform = TranslateTransform();
+    auto oldBaseTransform = TranslateTransform();
+    baseBlock.RenderTransform(newBaseTransform);
+    oldBase.RenderTransform(oldBaseTransform);
+
+    TranslateTransform newHiTransform{nullptr};
+    TranslateTransform oldHiTransform{nullptr};
+    if (hiBlock) {
+        newHiTransform = TranslateTransform();
+        hiBlock.RenderTransform(newHiTransform);
+    }
+    if (oldHi) {
+        oldHiTransform = TranslateTransform();
+        oldHi.RenderTransform(oldHiTransform);
+    }
+
+    Storyboard sb;
+    baseBlock.Opacity(0.0);
+    if (hiBlock) hiBlock.Opacity(0.0);
+    AppendDoubleAnimation(sb, oldBase, L"Opacity", 1.0, 0.0, durationMs);
+    AppendDoubleAnimation(sb, baseBlock, L"Opacity", 0.0, 1.0, durationMs);
+    if (oldHi) AppendDoubleAnimation(sb, oldHi, L"Opacity", 1.0, 0.0, durationMs);
+    if (hiBlock) AppendDoubleAnimation(sb, hiBlock, L"Opacity", 0.0, 1.0, durationMs);
+
+    sb.Completed([parentPanel, oldBase, oldHi, baseBlock, hiBlock](auto const&, auto const&) {
+        try {
+            RemovePanelChild(parentPanel, oldBase);
+            if (oldHi) RemovePanelChild(parentPanel, oldHi);
+            baseBlock.Opacity(1.0);
+            baseBlock.RenderTransform(TranslateTransform());
+            if (hiBlock) {
+                hiBlock.Opacity(1.0);
+                hiBlock.RenderTransform(TranslateTransform());
+                hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+            }
+        } catch (...) {}
+    });
+
+    try {
+        sb.Begin();
+    } catch (...) {
+        try {
+            RemovePanelChild(parentPanel, oldBase);
+            if (oldHi) RemovePanelChild(parentPanel, oldHi);
+            baseBlock.Opacity(1.0);
+            baseBlock.RenderTransform(TranslateTransform());
+            if (hiBlock) {
+                hiBlock.Opacity(1.0);
+                hiBlock.RenderTransform(TranslateTransform());
+                hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
+            }
+        } catch (...) {}
+    }
 }
 
 static double GetLyricProgress(const LyricLine& line, long long currentMs) {
@@ -4394,6 +4811,59 @@ static double GetLyricProgress(const LyricLine& line, long long currentMs) {
     return 1.0;
 }
 
+static bool ResolveDisplayedLyric(long long currentMs,
+                                  std::wstring& outText,
+                                  double& outProgress,
+                                  bool& outHide) {
+    outText.clear();
+    outProgress = 0.0;
+    outHide = false;
+
+    {
+        std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
+        for (const auto& line : g_lyricLines) {
+            if (currentMs >= line.startTimeMs && currentMs < line.startTimeMs + line.durationMs) {
+                if (!line.text.empty()) {
+                    outText = line.text;
+                    outProgress = GetLyricProgress(line, currentMs);
+                }
+                break;
+            }
+        }
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard<std::mutex> lk(g_lyricDisplayStateMtx);
+
+        if (!outText.empty()) {
+            g_lastLyricDisplayText = outText;
+            g_hasLastLyricDisplay = true;
+            g_lastLyricMatchTime = now;
+            return true;
+        }
+
+        if (g_settings.hideLyricWhenNoLyrics) {
+            if (g_hasLastLyricDisplay && g_settings.lyricHideDelay > 0) {
+                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    now - g_lastLyricMatchTime).count();
+                if (elapsed < g_settings.lyricHideDelay) {
+                    outText = g_lastLyricDisplayText;
+                    outProgress = 1.0;
+                    return !outText.empty();
+                }
+            }
+
+            outHide = true;
+            return false;
+        }
+    }
+
+    outText = L"🎵🎵🎵";
+    outProgress = 0.0;
+    return true;
+}
+
 static void UpdateLyricKaraokeFromCurrentPosition() {
     if (!g_playerGrid || !g_settings.showLyric || !g_settings.enableLyricKaraoke) return;
 
@@ -4429,33 +4899,13 @@ static void UpdateLyricKaraokeFromCurrentPosition() {
                 currentMs = estimated + g_settings.lyricTimeOffset;
             }
         }
-        {
-            std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
-            for (const auto& line : g_lyricLines) {
-                if (currentMs >= line.startTimeMs && currentMs < line.startTimeMs + line.durationMs) {
-                    text = line.text;
-                    progress = GetLyricProgress(line, currentMs);
-                    break;
-                }
-            }
-        }
+        bool hideLyric = false;
+        ResolveDisplayedLyric(currentMs, text, progress, hideLyric);
 
         if (!text.empty()) {
-            if (auto baseFe = FindChildByName(g_playerGrid, kLyricBaseName)) {
-                if (auto baseBlock = baseFe.try_as<TextBlock>()) {
-                    if (text != baseBlock.Text().c_str()) {
-                        baseBlock.Text(text);
-                    }
-                }
-            }
-            if (auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
-                if (auto hiBlock = hiFe.try_as<TextBlock>()) {
-                    hiBlock.Visibility(Visibility::Visible);
-                    if (text != hiBlock.Text().c_str()) {
-                        hiBlock.Text(text);
-                    }
-                }
-            }
+            SetLyricTextWithTransition(text, progress);
+        } else if (hideLyric) {
+            HideLyricDisplay();
         }
 
         UpdateLyricHighlightClip(progress);
@@ -5346,6 +5796,155 @@ static std::wstring HttpGetNetEase(const WCHAR* host, int port, const std::wstri
     return result;
 }
 
+static std::string WideToUtf8(const std::wstring& str) {
+    int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, str.c_str(),
+                                         (int)str.length(), NULL, 0, NULL, NULL);
+    if (sizeNeeded <= 0) return "";
+
+    std::string result(sizeNeeded, 0);
+    WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(),
+                        &result[0], sizeNeeded, NULL, NULL);
+    return result;
+}
+
+static std::wstring Utf8ToWide(const std::string& str) {
+    int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
+                                         (int)str.length(), NULL, 0);
+    if (sizeNeeded <= 0) return L"";
+
+    std::vector<wchar_t> result(sizeNeeded);
+    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.length(),
+                        result.data(), sizeNeeded);
+    return std::wstring(result.data(), result.size());
+}
+
+static std::wstring HttpGetQQMusic(const std::wstring& path) {
+    HINTERNET hSession = WinHttpOpen(L"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+                                     WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession) return L"";
+
+    HINTERNET hConnect = WinHttpConnect(hSession, L"c.y.qq.com", INTERNET_DEFAULT_HTTPS_PORT, 0);
+    if (!hConnect) { WinHttpCloseHandle(hSession); return L""; }
+
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", path.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (!hRequest) { WinHttpCloseHandle(hConnect); WinHttpCloseHandle(hSession); return L""; }
+
+    std::wstring headers =
+        L"Referer: https://y.qq.com/\r\n"
+        L"Accept: application/json, text/plain, */*\r\n"
+        L"sec-ch-ua: \"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Google Chrome\";v=\"146\"\r\n"
+        L"sec-ch-ua-mobile: ?0\r\n"
+        L"sec-ch-ua-platform: \"Windows\"\r\n";
+    WinHttpAddRequestHeaders(hRequest, headers.c_str(), (ULONG)-1, WINHTTP_ADDREQ_FLAG_ADD);
+
+    std::wstring result;
+    if (WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0)) {
+        if (WinHttpReceiveResponse(hRequest, NULL)) {
+            DWORD dwStatusCode = 0;
+            DWORD dwSize = sizeof(dwStatusCode);
+            WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+            if (dwStatusCode == 200) {
+                std::string rawResponse;
+                DWORD dwSizeAvail = 0;
+                do {
+                    if (!WinHttpQueryDataAvailable(hRequest, &dwSizeAvail)) break;
+                    if (dwSizeAvail == 0) break;
+                    std::vector<char> buffer(dwSizeAvail);
+                    DWORD dwDownloaded = 0;
+                    if (WinHttpReadData(hRequest, buffer.data(), dwSizeAvail, &dwDownloaded)) {
+                        rawResponse.append(buffer.data(), dwDownloaded);
+                    }
+                } while (dwSizeAvail > 0);
+
+                result = Utf8ToWide(rawResponse);
+            } else {
+                Wh_Log(L"QQ Music search returned error: %d", dwStatusCode);
+            }
+        }
+    }
+    WinHttpCloseHandle(hRequest);
+    WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    return result;
+}
+
+static std::wstring HttpPostQQMusic(const std::wstring& body) {
+    HINTERNET hSession = WinHttpOpen(L"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+                                     WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession) return L"";
+
+    HINTERNET hConnect = WinHttpConnect(hSession, L"u.y.qq.com", INTERNET_DEFAULT_HTTPS_PORT, 0);
+    if (!hConnect) { WinHttpCloseHandle(hSession); return L""; }
+
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"POST", L"/cgi-bin/musicu.fcg", NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (!hRequest) { WinHttpCloseHandle(hConnect); WinHttpCloseHandle(hSession); return L""; }
+
+    std::wstring headers =
+        L"Referer: https://y.qq.com/\r\n"
+        L"Origin: https://y.qq.com\r\n"
+        L"Content-Type: application/json;charset=UTF-8\r\n"
+        L"Accept: application/json, text/plain, */*\r\n";
+    WinHttpAddRequestHeaders(hRequest, headers.c_str(), (ULONG)-1, WINHTTP_ADDREQ_FLAG_ADD);
+
+    std::string utf8Body = WideToUtf8(body);
+    std::wstring result;
+    if (WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                           utf8Body.empty() ? WINHTTP_NO_REQUEST_DATA : (LPVOID)&utf8Body[0],
+                           (DWORD)utf8Body.size(), (DWORD)utf8Body.size(), 0)) {
+        if (WinHttpReceiveResponse(hRequest, NULL)) {
+            DWORD dwStatusCode = 0;
+            DWORD dwSize = sizeof(dwStatusCode);
+            WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+            if (dwStatusCode == 200) {
+                std::string rawResponse;
+                DWORD dwSizeAvail = 0;
+                do {
+                    if (!WinHttpQueryDataAvailable(hRequest, &dwSizeAvail)) break;
+                    if (dwSizeAvail == 0) break;
+                    std::vector<char> buffer(dwSizeAvail);
+                    DWORD dwDownloaded = 0;
+                    if (WinHttpReadData(hRequest, buffer.data(), dwSizeAvail, &dwDownloaded)) {
+                        rawResponse.append(buffer.data(), dwDownloaded);
+                    }
+                } while (dwSizeAvail > 0);
+
+                result = Utf8ToWide(rawResponse);
+            } else {
+                Wh_Log(L"QQ Music lyric returned error: %d", dwStatusCode);
+            }
+        }
+    }
+    WinHttpCloseHandle(hRequest);
+    WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    return result;
+}
+
+static std::wstring Base64DecodeToWide(const std::wstring& input) {
+    static constexpr wchar_t kBase64Chars[] =
+        L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::string decoded;
+    int val = 0;
+    int valb = -8;
+    for (wchar_t wc : input) {
+        if (wc == L'=') break;
+        const wchar_t* p = wcschr(kBase64Chars, wc);
+        if (!p) continue;
+
+        val = (val << 6) + (int)(p - kBase64Chars);
+        valb += 6;
+        if (valb >= 0) {
+            decoded.push_back((char)((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+
+    return Utf8ToWide(decoded);
+}
+
 static std::wstring CleanMediaString(std::wstring str) {
     size_t pOpen = str.find(L'(');
     if (pOpen != std::wstring::npos) str = str.substr(0, pOpen);
@@ -5374,6 +5973,132 @@ static std::wstring CleanMediaString(std::wstring str) {
         str = str.substr(0, last + 1);
     }
     return str;
+}
+
+static bool FetchFromQQMusic(const std::wstring& title, const std::wstring& artist,
+                             const std::wstring& album, long durationMs,
+                             std::vector<LyricLine>& outLyrics) {
+    (void)album;
+
+    auto ReplaceAll = [](std::wstring& s, const std::wstring& from, const std::wstring& to) {
+        size_t pos = 0;
+        while ((pos = s.find(from, pos)) != std::wstring::npos) {
+            s.replace(pos, from.length(), to);
+            pos += to.length();
+        }
+    };
+
+    auto ExtractLyrics = [&](const std::wstring& songMid) -> bool {
+        if (songMid.empty()) return false;
+
+        std::wstring body =
+            L"{\"comm\":{\"ct\":24,\"cv\":0},\"lyric\":{\"module\":\"music.musichallSong.PlayLyricInfo\","
+            L"\"method\":\"GetPlayLyricInfo\",\"param\":{\"songMID\":\"" + songMid +
+            L"\",\"songID\":0,\"trans\":1,\"roma\":1,\"crypt\":0,\"lrc_t\":0,\"qrc\":0,\"type\":0}}}";
+
+        std::wstring lyricJson = HttpPostQQMusic(body);
+        if (lyricJson.empty()) return false;
+
+        try {
+            JsonObject root = JsonObject::Parse(lyricJson);
+            if (!root.HasKey(L"lyric")) return false;
+
+            JsonObject lyricResp = root.GetNamedObject(L"lyric");
+            if (!lyricResp.HasKey(L"data")) return false;
+
+            JsonObject data = lyricResp.GetNamedObject(L"data");
+            std::wstring lrc;
+            if (data.HasKey(L"lyric") &&
+                data.GetNamedValue(L"lyric").ValueType() == JsonValueType::String) {
+                lrc = data.GetNamedString(L"lyric").c_str();
+            }
+            if (lrc.empty() && data.HasKey(L"qrc") &&
+                data.GetNamedValue(L"qrc").ValueType() == JsonValueType::String) {
+                lrc = data.GetNamedString(L"qrc").c_str();
+            }
+            if (lrc.empty()) return false;
+
+            std::wstring decoded = Base64DecodeToWide(lrc);
+            if (!decoded.empty() && decoded.find(L'[') != std::wstring::npos) {
+                lrc = decoded;
+            }
+
+            ReplaceAll(lrc, L"\\n", L"\n");
+            ReplaceAll(lrc, L"\\\"", L"\"");
+            ReplaceAll(lrc, L"\\r", L"");
+            ReplaceAll(lrc, L"\r", L"");
+
+            outLyrics = LRCParser::Parse(lrc, durationMs);
+            return !outLyrics.empty();
+        }
+        catch (...) {
+        }
+
+        return false;
+    };
+
+    std::vector<std::wstring> queries;
+    auto AddQuery = [&](const std::wstring& query) {
+        if (!query.empty() &&
+            std::find(queries.begin(), queries.end(), query) == queries.end()) {
+            queries.push_back(query);
+        }
+    };
+
+    if (!artist.empty()) {
+        AddQuery(title + L"-" + artist);
+        AddQuery(title + L" - " + artist);
+        AddQuery(title + L" " + artist);
+        AddQuery(artist + L" " + title);
+    }
+    AddQuery(title);
+    AddQuery(artist);
+
+    std::set<std::wstring> triedSongMids;
+    for (const auto& query : queries) {
+        std::wstring searchPath =
+            L"/splcloud/fcgi-bin/smartbox_new.fcg?is_xml=0&format=json&key=" +
+            URLEncode(query) +
+            L"&g_tk=5381&loginUin=0&hostUin=0&inCharset=utf8&outCharset=utf-8"
+            L"&notice=0&platform=yqq.json&needNewCode=0";
+
+        std::wstring searchJson = HttpGetQQMusic(searchPath);
+        if (searchJson.empty()) continue;
+
+        try {
+            JsonObject root = JsonObject::Parse(searchJson);
+            if (!root.HasKey(L"data")) continue;
+
+            JsonObject data = root.GetNamedObject(L"data");
+            if (!data.HasKey(L"song")) continue;
+
+            JsonObject song = data.GetNamedObject(L"song");
+            if (!song.HasKey(L"itemlist")) continue;
+
+            JsonArray itemList = song.GetNamedArray(L"itemlist");
+            for (uint32_t i = 0; i < itemList.Size(); i++) {
+                JsonObject item = itemList.GetAt(i).GetObject();
+                if (!item.HasKey(L"mid") ||
+                    item.GetNamedValue(L"mid").ValueType() != JsonValueType::String) {
+                    continue;
+                }
+
+                std::wstring songMid = item.GetNamedString(L"mid").c_str();
+                if (songMid.empty() || triedSongMids.find(songMid) != triedSongMids.end()) {
+                    continue;
+                }
+                triedSongMids.insert(songMid);
+
+                if (ExtractLyrics(songMid)) {
+                    return true;
+                }
+            }
+        }
+        catch (...) {
+        }
+    }
+
+    return false;
 }
 
 static bool FetchFromNetEase(const std::wstring& title, const std::wstring& artist,
@@ -5510,7 +6235,11 @@ static void FetchLyrics(const std::wstring& title, const std::wstring& artist,
     std::wstring cleanTitle = CleanMediaString(title);
     std::wstring cleanAlbum = CleanMediaString(album);
 
-    if (FetchFromNetEase(cleanTitle, artist, cleanAlbum, durationMs, lines)) {
+    if (FetchFromQQMusic(cleanTitle, artist, cleanAlbum, durationMs, lines)) {
+        Wh_Log(L"Lyrics found from QQ Music");
+        found = true;
+    }
+    else if (FetchFromNetEase(cleanTitle, artist, cleanAlbum, durationMs, lines)) {
         Wh_Log(L"Lyrics found from NetEase");
         found = true;
     }
@@ -6950,6 +7679,15 @@ static Grid BuildPlayerGrid() {
                     lyricRoot.Name(kLyricRootName);
                     lyricRoot.VerticalAlignment(VerticalAlignment::Center);
                     lyricRoot.Margin({(double)g_settings.lyricMarginLeft, 0, (double)g_settings.lyricMarginRight, 0});
+                    {
+                        auto geo = winrt::Windows::UI::Xaml::Media::RectangleGeometry();
+                        lyricRoot.Clip(geo);
+                        lyricRoot.SizeChanged([geo](winrt::Windows::Foundation::IInspectable const&, winrt::Windows::UI::Xaml::SizeChangedEventArgs const& e) mutable {
+                            try {
+                                geo.Rect({0, 0, (float)e.NewSize().Width, (float)e.NewSize().Height});
+                            } catch (...) {}
+                        });
+                    }
                     lyricBlock.Margin({0, 0, 0, 0});
                     lyricHighlightBlock.Margin({0, 0, 0, 0});
                     lyricRoot.Children().Append(lyricBlock);
@@ -8761,24 +9499,17 @@ static void RefreshPlayerContents() {
             if (auto lyricFe = FindChildByName(g_playerGrid, kLyricBaseName)) {
                 if (auto lyricBlock = lyricFe.try_as<TextBlock>()) {
                     double lyricProgress = 0.0;
+                    bool hideLyric = false;
                     std::wstring timeText = L"🎵🎵🎵";
                     long long currentMs = 0;
                     {
                         std::lock_guard<std::mutex> lk(g_mediaMtx);
                         currentMs = g_media.currentPositionMs + g_settings.lyricTimeOffset;
                     }
-                    {
-                        std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
-                        for (const auto& line : g_lyricLines) {
-                            if (currentMs >= line.startTimeMs && currentMs < line.startTimeMs + line.durationMs) {
-                                if (!line.text.empty()) {
-                                    timeText = line.text;
-                                }
-                                lyricProgress = GetLyricProgress(line, currentMs);
-                                break;
-                            }
-                        }
-                    }
+                    ResolveDisplayedLyric(currentMs, timeText, lyricProgress, hideLyric);
+                    if (hideLyric) {
+                        HideLyricDisplay();
+                    } else {
                     if (timeText == L"🎵🎵🎵" && g_settings.hideLyricWhenNoLyrics) {
                         if (g_settings.lyricMaxWidth > 0) {
                             if (auto cv = FindChildByName(g_playerGrid, kLyricScrollViewName)) {
@@ -8803,18 +9534,9 @@ static void RefreshPlayerContents() {
                                     root.Visibility(Visibility::Visible);
                             }
                         }
-                        if (timeText != lyricBlock.Text().c_str()) {
-                            lyricBlock.Text(timeText);
-                        }
-                        if (auto hiFe = FindChildByName(g_playerGrid, kLyricHighlightName)) {
-                            if (auto hiBlock = hiFe.try_as<TextBlock>()) {
-                                hiBlock.Visibility(g_settings.enableLyricKaraoke ? Visibility::Visible : Visibility::Collapsed);
-                                if (timeText != hiBlock.Text().c_str()) {
-                                    hiBlock.Text(timeText);
-                                }
-                            }
-                        }
+                        SetLyricTextWithTransition(timeText, lyricProgress);
                         UpdateLyricHighlightClip(g_settings.enableLyricKaraoke ? lyricProgress : 0.0);
+                    }
                     }
                     // Update lyric scroll state
                     if (g_settings.lyricMaxWidth > 0) {
@@ -8849,6 +9571,13 @@ static void RefreshPlayerContents() {
             {
                 std::lock_guard<std::mutex> lk(g_lyricLinesMtx);
                 g_lyricLines.clear();
+            }
+            {
+                std::lock_guard<std::mutex> lk(g_lyricDisplayStateMtx);
+                g_lastLyricDisplayText.clear();
+                g_hasLastLyricDisplay = false;
+                g_lyricDisplayHidden = true;
+                g_lastLyricMatchTime = std::chrono::steady_clock::now();
             }
             Wh_Log(L"RefreshPlayerContents: Fetching lyrics for '%s' - '%s'", fetchTitle.c_str(), fetchArtist.c_str());
             std::thread([fetchTitle, fetchArtist, fetchAlbum, fetchDuration]() {


### PR DESCRIPTION
## Summary

This PR adds synced lyric support to the taskbar media player and enhances it with a karaoke-style highlight effect.

<img width="583" height="48" alt="image" src="https://github.com/user-attachments/assets/ffcbf32b-ea46-4cb5-ab60-03cdd4f20aaa" />

## Changes

- Add lyric display next to the media controls.
- Fetch synced lyrics for the current track from supported lyric providers.
- Parse standard LRC timestamps and enhanced per-word LRC timestamps.
- Add karaoke-style lyric highlighting:
  - Base lyric color is configurable.
  - Highlight color is configurable.
  - Highlight progress updates smoothly during playback.
  - Per-word timing is used when available, with line-based fallback otherwise.
- Keep lyric scrolling compatible with the highlight layer for long lyric lines.
- Add settings for:
  - Showing lyrics
  - Lyric margin
  - Base lyric color
  - Karaoke effect toggle
  - Highlight color
  - Max lyric width
  - Lyric timing offset
  - Hiding the lyric area when no lyrics are available

## Notes

The karaoke effect uses a layered `TextBlock` approach: the base lyric is rendered normally, while the highlight layer is clipped according to the current lyric progress. This keeps the implementation lightweight and consistent with the existing XAML UI structure.

## Testing

Tested locally with NetEase Cloud Music.

Verified that:

- Synced lyrics are fetched and displayed correctly.
- Karaoke highlighting progresses smoothly during playback.
- Custom base and highlight colors work as expected.
- Long lyrics continue to scroll correctly with the highlight effect.s.